### PR TITLE
removing strikethrough on missed rounds

### DIFF
--- a/src/components/IndividualPerformance.js
+++ b/src/components/IndividualPerformance.js
@@ -695,7 +695,7 @@ const IndividualPerformance = ({ data, season }) => {
 													{submission.forfeited ? (
 														<MuiTooltip title="Votes forfeited — didn't vote this round" arrow>
 															<Box component="span" sx={{ color: 'error.main' }}>
-																<Box component="span" sx={{ textDecoration: 'line-through' }}>
+																<Box component="span">
 																	{submission.rawVotes}
 																</Box>
 																{' → 0'}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts styling in the `IndividualPerformance` submissions table without changing data calculations or behavior.
> 
> **Overview**
> Removes the *strikethrough* formatting from forfeited vote counts in `IndividualPerformance` while keeping the existing tooltip and red "raw votes → 0" indicator for missed voting rounds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f62338b787c7b76dab54fa241364a63bf80d1be8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->