### PR TITLE
fixed compatibility score rounding

### DIFF
--- a/src/utils/dataProcessor.js
+++ b/src/utils/dataProcessor.js
@@ -689,7 +689,7 @@ export const calculateMostCompatible = (votes, submissions, competitors) => {
 		restOfField,
 		isTied,
 		tiedWinners: tiedWinnersNames,
-		tiedPairs: isTied ? tiedPairs : null
+		tiedPairs: isTied ? tiedPairs.map(p => ({ ...p, score: p.score.toFixed(2) })) : null
 	};
 };
 
@@ -809,7 +809,7 @@ export const calculateLeastCompatible = (votes, submissions, competitors) => {
 		restOfField,
 		isTied,
 		tiedWinners: tiedWinnersNames,
-		tiedPairs: isTied ? tiedPairs : null
+		tiedPairs: isTied ? tiedPairs.map(p => ({ ...p, score: p.score.toFixed(2) })) : null
 	};
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts formatting of `tiedPairs` compatibility scores for tie scenarios, without changing ranking or underlying calculations.
> 
> **Overview**
> Ensures compatibility tie details display consistently rounded scores by formatting each `tiedPairs[].score` to `toFixed(2)` in both `calculateMostCompatible` and `calculateLeastCompatible`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ff79927b4760b3663da603704cc098a5e4565b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->